### PR TITLE
Encode filename as RFC5987

### DIFF
--- a/src/routes/file.ts
+++ b/src/routes/file.ts
@@ -77,7 +77,17 @@ router.get('/', requireQuery({
     const filename = fileHeader.name ?? 'sample.json';
     const mimetype = mime.lookup(filename);
 
-    res.setHeader(`Content-disposition`, `attachment; filename="${filename}"`);
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_content-disposition_and_link_headers
+    function encodeRFC5987ValueChars(str: string) {
+        return (
+          encodeURIComponent(str)
+            .replace(/['()]/g, escape)
+            .replace(/\*/g, "%2A")
+            .replace(/%(?:7C|60|5E)/g, unescape)
+        );
+      }
+
+    res.setHeader(`Content-disposition`, `attachment; filename*=UTF-8''${encodeRFC5987ValueChars(filename)}`);
     res.setHeader('Content-type', mimetype || 'text/plain');
 
     fileData.pipe(res);


### PR DESCRIPTION
fix: #10 
RFC5987 규격대로 인코딩합니다.

https://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http

코드는

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_content-disposition_and_link_headers

를 참조했습니다.